### PR TITLE
support set of non terminated string (with len)

### DIFF
--- a/lib/capn.c
+++ b/lib/capn.c
@@ -1052,7 +1052,8 @@ capn_ptr capn_new_string(struct capn_segment *seg, const char *str, ssize_t sz) 
 	p.datasz = 1;
 	new_object(&p, p.len);
 	if (p.data) {
-		memcpy(p.data, str, p.len-1);
+		memcpy(p.data, str, p.len - 1);
+		p.data[p.len - 1] = '\0';
 	}
 	return p;
 }


### PR DESCRIPTION
This allows one to send a part of a string via in a message without modifying the original string
for example if you have path `/a/b/c/d/test.txt`
you can send a legal null terminated `/a/` without modifying the original one by putting null after `/a/`

for example 
```
void capn_text_set(const char *str, capn_text *out_capn)
{
    out_capn->str = str;
    out_capn->len = -1;
    out_capn->seg = NULL;
}

void capn_text_set_with_len(const char *str, const size_t str_len, capn_text *out_capn)
{
    out_capn->str = str;
    out_capn->len = str_len;
    out_capn->seg = NULL;
}
```