### PR TITLE
lib: make buf arg const in write_fd pointer

### DIFF
--- a/lib/capn-malloc.c
+++ b/lib/capn-malloc.c
@@ -304,7 +304,7 @@ capn_write_mem(struct capn *c, uint8_t *p, size_t sz, int packed)
 	return headersz+datasz;
 }
 
-static int _write_fd(ssize_t (*write_fd)(int fd, void *p, size_t count), int fd, void *p, size_t count)
+static int _write_fd(ssize_t (*write_fd)(int fd, const void *p, size_t count), int fd, void *p, size_t count)
 {
 	ssize_t ret;
 	size_t sent = 0;
@@ -323,7 +323,7 @@ static int _write_fd(ssize_t (*write_fd)(int fd, void *p, size_t count), int fd,
 	return 0;
 }
 
-int capn_write_fd(struct capn *c, ssize_t (*write_fd)(int fd, void *p, size_t count), int fd, int packed)
+int capn_write_fd(struct capn *c, ssize_t (*write_fd)(int fd, const void *p, size_t count), int fd, int packed)
 {
 	unsigned char buf[4096];
 	struct capn_segment *seg;

--- a/lib/capnp_c.h
+++ b/lib/capnp_c.h
@@ -266,7 +266,7 @@ int capn_init_mem(struct capn *c, const uint8_t *p, size_t sz, int packed);
  */
 /* TODO */
 /*int capn_write_fp(struct capn *c, FILE *f, int packed);*/
-int capn_write_fd(struct capn *c, ssize_t (*write_fd)(int fd, void *p, size_t count), int fd, int packed);
+int capn_write_fd(struct capn *c, ssize_t (*write_fd)(int fd, const void *p, size_t count), int fd, int packed);
 int capn_write_mem(struct capn *c, uint8_t *p, size_t sz, int packed);
 
 void capn_free(struct capn *c);


### PR DESCRIPTION
For capn_write_fd() the write() function would be ideal to pass as
write_fd, but write() has type ssize_t (*)(int, const void *, size_t),
whereas write_fd expects ssize_t (*)(int, void *, size_t). Passing
write() directly with GCC 5.4 causes a warning
-Wincompatible-pointer-types (on by default).
