### PR TITLE
Fix GCC warnings in initializers for capn_val0 and capn_seg.

### DIFF
--- a/compiler/capnpc-c.c
+++ b/compiler/capnpc-c.c
@@ -1348,7 +1348,7 @@ int main() {
 		fprintf(srcf, "/* AUTO GENERATED - DO NOT EDIT */\n");
 
 		if (g_val0used)
-			fprintf(srcf, "static const capn_text capn_val0 = {0,\"\"};\n");
+			fprintf(srcf, "static const capn_text capn_val0 = {0,\"\",0};\n");
 		if (g_nullused)
 			fprintf(srcf, "static const capn_ptr capn_null = {CAPN_NULL};\n");
 
@@ -1364,7 +1364,7 @@ int main() {
 			}
 			fprintf(srcf, "\n};\n");
 
-			fprintf(srcf, "static const struct capn_segment capn_seg = {{0},0,0,0,(char*)&capn_buf[0],%lu,%lu};\n",
+			fprintf(srcf, "static const struct capn_segment capn_seg = {{0},0,0,0,(char*)&capn_buf[0],%lu,%lu,0};\n",
 					g_valseg.len-8, g_valseg.len-8);
 		}
 


### PR DESCRIPTION
I received 2 GCC warnings building a .c file generated by c-capnproto due to missing field initializers.

These are the messages:
```
target/src-generated/capnproto/hi.capnp.c:3:1: error: missing initializer for field 'seg' of 'capn_text {aka const struct capn_text}' [-Werror=missing-field-initializers]
 static const capn_text capn_val0 = {0,""};
 ^
compilation terminated due to -Wfatal-errors.
cc1: all warnings being treated as errors
```

```
target/src-generated/capnproto/hi.capnp.c:8:21: error: missing initializer for field 'user' of 'const struct capn_segment' [-Werror=missing-field-initializers]
 static const struct capn_segment capn_seg = {{0},0,0,0,(char*)&capn_buf[0],16,16};
                     ^
compilation terminated due to -Wfatal-errors.
cc1: all warnings being treated as errors
```

The attached diff adds extra field initializers so the whole stuct is initialized and GCC stops complaining. Tested successfully on my machine by running `make && make check`.