### PR TITLE
Fix runtime library compiler warnings and errors in GCC.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ Makefile
 Makefile.in
 .deps
 .libs
+.dirstamp
 
 test-driver
 *.log

--- a/lib/capn-malloc.c
+++ b/lib/capn-malloc.c
@@ -19,10 +19,15 @@
 #include <limits.h>
 #include <errno.h>
 
-/* Visual Studio notes:
- * Unless capn_segment is defined with __declspec(align(64)), check_segment_alignment
- * Fails to compile in x86 mode, as (sizeof(struct capn_segment)&7) -> (44 & 7) evaluates to 4
- * Compiles in x64 mode, as (sizeof(struct capn_segment)&7) -> (80 & 7) evaluates to 0
+/*
+ * 8 byte alignment is required for struct capn_segment.
+ * This struct check_segment_alignment verifies this at compile time.
+ *
+ * Unless capn_segment is defined with 8 byte alignment, check_segment_alignment
+ * fails to compile in x86 mode (or on another CPU with 32-bit pointers),
+ * as (sizeof(struct capn_segment)&7) -> (44 & 7) evaluates to 4.
+ * It compiles in x64 mode (or on another CPU with 64-bit pointers),
+ * as (sizeof(struct capn_segment)&7) -> (80 & 7) evaluates to 0.
  */
 struct check_segment_alignment {
 	unsigned int foo : (sizeof(struct capn_segment)&7) ? -1 : 1;

--- a/lib/capn-malloc.c
+++ b/lib/capn-malloc.c
@@ -8,6 +8,10 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
+
 #include "capnp_c.h"
 #include "capnp_priv.h"
 #include <stdlib.h>
@@ -25,10 +29,6 @@ struct check_segment_alignment {
 };
 
 static struct capn_segment *create(void *u, uint32_t id, int sz) {
-	// Silence warnings about unused parameters.
-	UNUSED(u);
-	UNUSED(id);
-
 	struct capn_segment *s;
 	sz += sizeof(*s);
 	if (sz < 4096) {

--- a/lib/capn-malloc.c
+++ b/lib/capn-malloc.c
@@ -25,6 +25,10 @@ struct check_segment_alignment {
 };
 
 static struct capn_segment *create(void *u, uint32_t id, int sz) {
+	// Silence warnings about unused parameters.
+	UNUSED(u);
+	UNUSED(id);
+
 	struct capn_segment *s;
 	sz += sizeof(*s);
 	if (sz < 4096) {

--- a/lib/capn.c
+++ b/lib/capn.c
@@ -7,7 +7,9 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
+#ifdef __GNUC__
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
 
 #include "capnp_c.h"
 

--- a/lib/capn.c
+++ b/lib/capn.c
@@ -7,6 +7,8 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+
 #include "capnp_c.h"
 
 #include <stdlib.h>

--- a/lib/capnp_c.h
+++ b/lib/capnp_c.h
@@ -13,11 +13,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
-
-// ssize_t is defined in unistd.h in GCC.
-#ifdef __GNUC__
 #include <unistd.h>
-#endif
 
 #if defined(unix) && !defined(__APPLE__)
 #include <endian.h>
@@ -33,7 +29,7 @@ typedef intmax_t ssize_t;
 #define UNUSED(x) (void)(x)
 #endif
 
-// Cross-platform macro ALIGNED_(x) aligns a struct by `x` bits.
+// Cross-platform macro ALIGNED_(x) aligns a struct by `x` bytes.
 #ifdef _MSC_VER
 #define ALIGNED_(x) __declspec(align(x))
 #endif

--- a/lib/capnp_c.h
+++ b/lib/capnp_c.h
@@ -24,11 +24,6 @@
 typedef intmax_t ssize_t;
 #endif
 
-// Macro UNUSED(x) silences compiler warnings about unused parameter or variable `x`.
-#ifndef UNUSED
-#define UNUSED(x) (void)(x)
-#endif
-
 // Cross-platform macro ALIGNED_(x) aligns a struct by `x` bytes.
 #ifdef _MSC_VER
 #define ALIGNED_(x) __declspec(align(x))

--- a/lib/capnp_c.h
+++ b/lib/capnp_c.h
@@ -103,18 +103,19 @@ struct capn_tree *capn_tree_insert(struct capn_tree *root, struct capn_tree *n);
  *
  * cap specifies the segment capacity.
  *
- * When creating new structures len will be incremented until it reaces cap,
+ * When creating new structures len will be incremented until it reaches cap,
  * at which point a new segment will be requested via capn->create. The
  * create callback can either create a new segment or expand an existing
  * one by incrementing cap and returning the expanded segment.
  *
- * data, len, and cap must all by 8 byte aligned
+ * data, len, and cap must all be 8 byte aligned, hence the ALIGNED_(8) macro
+ * on the struct definition.
  *
- * data, len, cap, and user should all set by the user. Other values
+ * data, len, cap, and user should all be set by the user. Other values
  * should be zero initialized.
  */
 
-struct ALIGNED_(64) capn_segment {
+struct ALIGNED_(8) capn_segment {
 	struct capn_tree hdr;
 	struct capn_segment *next;
 	struct capn *capn;

--- a/lib/capnp_c.h
+++ b/lib/capnp_c.h
@@ -13,6 +13,12 @@
 
 #include <stdint.h>
 #include <stdio.h>
+
+// ssize_t is defined in unistd.h in GCC.
+#ifdef __GNUC__
+#include <unistd.h>
+#endif
+
 #if defined(unix) && !defined(__APPLE__)
 #include <endian.h>
 #endif
@@ -20,6 +26,19 @@
 // ssize_t is not defined in stdint.h in MSVC.
 #ifdef _MSC_VER
 typedef intmax_t ssize_t;
+#endif
+
+// Macro UNUSED silences compiler warnings about unused parameters.
+#ifndef UNUSED
+#define UNUSED(x) (void)(x)
+#endif
+
+// Cross-platform macro ALIGNED_(x) aligns a struct by x bits.
+#ifdef _MSC_VER
+#define ALIGNED_(x) __declspec(align(x))
+#endif
+#ifdef __GNUC__
+#define ALIGNED_(x) __attribute__ ((aligned(x)))
 #endif
 
 #ifdef __cplusplus
@@ -103,10 +122,8 @@ struct capn_tree *capn_tree_insert(struct capn_tree *root, struct capn_tree *n);
  * data, len, cap, and user should all set by the user. Other values
  * should be zero initialized.
  */
-#ifdef _MSC_VER
-__declspec(align(64))
-#endif
-struct capn_segment {
+
+struct ALIGNED_(64) capn_segment {
 	struct capn_tree hdr;
 	struct capn_segment *next;
 	struct capn *capn;

--- a/lib/capnp_c.h
+++ b/lib/capnp_c.h
@@ -28,12 +28,12 @@
 typedef intmax_t ssize_t;
 #endif
 
-// Macro UNUSED silences compiler warnings about unused parameters.
+// Macro UNUSED(x) silences compiler warnings about unused parameter or variable `x`.
 #ifndef UNUSED
 #define UNUSED(x) (void)(x)
 #endif
 
-// Cross-platform macro ALIGNED_(x) aligns a struct by x bits.
+// Cross-platform macro ALIGNED_(x) aligns a struct by `x` bits.
 #ifdef _MSC_VER
 #define ALIGNED_(x) __declspec(align(x))
 #endif


### PR DESCRIPTION
I tested these changes with `make check` and by building the runtime library in my own project.