### PR TITLE
Support creation of struct lists with size 0

### DIFF
--- a/lib/capn.c
+++ b/lib/capn.c
@@ -1006,9 +1006,7 @@ capn_ptr capn_new_list(struct capn_segment *seg, int sz, int datasz, int ptrs) {
 	p.seg = seg;
 	p.len = sz;
 
-	if (!sz) {
-		/* empty lists may as well be a len=0 void list */
-	} else if (ptrs || datasz > 8) {
+	if (ptrs || datasz > 8) {
 		p.is_composite_list = 1;
 		p.datasz = (datasz + 7) & ~7;
 		p.ptrs = ptrs;


### PR DESCRIPTION
The case of creating capnp lists of size 0 didn't consider lists of
composite elements (structs), which requires the addition of list
element information.

This commit removes the case of size 0 when creating the list in order
to enable the creation of 0 sized lists of any element type (struct).