### PR TITLE
compiler: Allocate all possible space for constants

### DIFF
--- a/compiler/capnpc-c.c
+++ b/compiler/capnpc-c.c
@@ -1179,14 +1179,22 @@ int main() {
 	struct node *file_node, *n;
 	struct node *all_files = NULL, *all_structs = NULL;
 	int i, j;
+	uint64_t total_len=0;
+	struct capn_segment *current_seg;
 
-	if (capn_init_fp(&capn, stdin, 0)) {
+	if (capn_init_fp(&capn, stdin, 0)==-1) {
 		fprintf(stderr, "failed to read schema from stdin\n");
 		return -1;
 	}
 
-	g_valseg.data = calloc(1, capn.seglist->len);
-	g_valseg.cap = capn.seglist->len;
+	current_seg = capn.seglist;
+	do{
+		total_len+=current_seg->len;
+		current_seg = current_seg->next;
+	}while(current_seg);
+
+	g_valseg.data = calloc(1, total_len);
+	g_valseg.cap = total_len;
 
 	root.p = capn_getp(capn_root(&capn), 0, 1);
 	read_CodeGeneratorRequest(&req, root);


### PR DESCRIPTION
When the c-capnp compiler runs, currently only takes the len of 1st
segment in the list as a capacity used in the generator for constants
definitions.

This works when the schema processing only generates 1 segment, or the
1st segment has 8192 bytes. There are cases where the fd returns
multiple segments an the first one has very low capacity (e.g. 96 or 80).
Hence, if more constants require to be allocated for the current schema
it will have misleading positions.

This commit takes a conservative approach by summing up all the lenghts
of capnproto segments obtained at the fd_init call of the compiler.
Those values are taken to set the memory allocation and the max
capacity for the segment utilized in the code generation.