### PR TITLE
compiler/str.h: include stdarg.h for va_list

### DIFF
--- a/compiler/str.h
+++ b/compiler/str.h
@@ -9,6 +9,7 @@
 
 #include <capnp_c.h>
 #include <stdlib.h>
+#include <stdarg.h>
 
 struct str {
 	char *str;


### PR DESCRIPTION
With some toolchains, compilation of str.c produced the following error:

compiler/str.h:56:50: error: unknown type name ‘va_list’
 int str_vaddf(struct str *v, const char *format, va_list ap) ATTR(2,0);
                                                  ^~~~~~~

One toolchain had the following in its stdarg.h:
"We deliberately do not define va_list when called from
stdio.h, because ANSI C says that stdio.h is not supposed to
define va_list."

str.c includes stdio.h, but none of the prior includes result in the
inclusion of stdarg.h. Therefore, explicitly include it in str.h to fix
the issue on toolchains following this ANSI C rule.

Signed-off-by: Joel Carlson <JoelsonCarl@gmail.com>