### PR TITLE
Implemented capn_size() for calculating buffer size

### DIFF
--- a/lib/capn-malloc.c
+++ b/lib/capn-malloc.c
@@ -410,7 +410,6 @@ int capn_write_fd(struct capn *c, ssize_t (*write_fd)(int fd, const void *p, siz
 
 int capn_size(struct capn *c)
 {
-	uint32_t headerlen;
 	size_t headersz, datasz = 0;
 	struct capn_ptr root;
 	struct capn_segment *seg;
@@ -421,7 +420,8 @@ int capn_size(struct capn *c)
 
 	root = capn_root(c);
 	seg = root.seg;
-	header_calc(c, &headerlen, &headersz);
+
+    headersz = 8 * ((2 + c->segnum) / 2);
 
 	for (i = 0; i < c->segnum; i++, seg = seg->next) {
 		if (0 == seg)

--- a/lib/capn-malloc.c
+++ b/lib/capn-malloc.c
@@ -407,3 +407,29 @@ int capn_write_fd(struct capn *c, ssize_t (*write_fd)(int fd, const void *p, siz
 
 	return datasz;
 }
+
+int capn_size(struct capn *c)
+{
+	uint32_t headerlen;
+	size_t headersz, datasz = 0;
+	struct capn_ptr root;
+	struct capn_segment *seg;
+	int i;
+
+	if (c->segnum == 0)
+		return -1;
+
+	root = capn_root(c);
+	seg = root.seg;
+	header_calc(c, &headerlen, &headersz);
+
+	for (i = 0; i < c->segnum; i++, seg = seg->next) {
+		if (0 == seg)
+			return -1;
+		datasz += seg->len;
+	}
+	if (0 != seg)
+		return -1;
+
+	return (int) headersz+datasz;
+}

--- a/lib/capnp_c.h
+++ b/lib/capnp_c.h
@@ -276,9 +276,11 @@ void capn_init_malloc(struct capn *c);
 int capn_init_fp(struct capn *c, FILE *f, int packed);
 int capn_init_mem(struct capn *c, const uint8_t *p, size_t sz, int packed);
 
-/* capn_size calculates the amount of memory required for the buffer passed to
- * capn_write_mem. It does not calculate the size for packed serialization, but
- * that will always be less than the unpacked size.
+/* capn_size() calculates the amount of memory required to serialise the given
+ * Cap'n Proto structure in the unpacked format. It does NOT apply to packed
+ * serialisation, as that may (in rare cases) actually become bigger than the
+ * input. A buffer of this size can then be passed to capn_write_mem() without
+ * fear of truncation (again, only in the unpacked case).
  */
 int capn_size(struct capn *c);
 

--- a/lib/capnp_c.h
+++ b/lib/capnp_c.h
@@ -276,6 +276,12 @@ void capn_init_malloc(struct capn *c);
 int capn_init_fp(struct capn *c, FILE *f, int packed);
 int capn_init_mem(struct capn *c, const uint8_t *p, size_t sz, int packed);
 
+/* capn_size calculates the amount of memory required for the buffer passed to
+ * capn_write_mem. It does not calculate the size for packed serialization, but
+ * that will always be less than the unpacked size.
+ */
+int capn_size(struct capn *c);
+
 /* capn_write_(fp|mem) writes segments to the file/memory buffer in
  * serialized form and returns the number of bytes written.
  */


### PR DESCRIPTION
This is a first pass at implementing what's requested in #26. It adds a function `capn_size()` that calculates the size required for a buffer passed to `capn_write_mem()`.

Notes:

- I did not implement the calculation for a packed structure. I couldn't figure out how to do it without doing the serialisation first, which requires a buffer of the right size, which is a circular problem.

- **Please confirm** that my comment is correct ie. that packed serialisation will never require more memory than unpacked. Then you at least have the guarantee that a buffer of size `capn_size()` is suitable for both packed and unpacked calls.

- I did not change the existing tests for `capn_write_mem()`, since that seemed like testing two functions in one test. Using a pre-sized buffer for those tests seems like the right thing to do even with a size function.