### PR TITLE
Make enums generate uint16_t instead of enums for binary compatibility.

### DIFF
--- a/compiler/capnpc-c.c
+++ b/compiler/capnpc-c.c
@@ -113,16 +113,13 @@ static void resolve_names(struct str *b, struct node *n, capn_text name, struct 
 static void define_enum(struct node *n) {
 	int i;
 
-	str_addf(&HDR, "\nenum %s {", n->name.str);
+	str_addf(&HDR, "\ntypedef uint16_t %s;", n->name.str);
 	for (i = 0; i < capn_len(n->n._enum.enumerants); i++) {
 		struct Enumerant e;
 		get_Enumerant(&e, n->n._enum.enumerants, i);
-		if (i) {
-			str_addf(&HDR, ",");
-		}
-		str_addf(&HDR, "\n\t%s_%s = %d", n->name.str, e.name.str, i);
+		str_addf(&HDR, "\n#define %s_%s (%dU)", n->name.str, e.name.str, i);
 	}
-	str_addf(&HDR, "\n};\n");
+	str_addf(&HDR, "\n\n");
 }
 
 static void decode_value(struct value* v, Type_ptr type, Value_ptr value, const char *symbol) {
@@ -175,7 +172,7 @@ static void decode_value(struct value* v, Type_ptr type, Value_ptr value, const 
 		v->tname = "capn_data";
 		break;
 	case Type__enum:
-		v->tname = strf(&v->tname_buf, "enum %s", find_node(v->t._enum.typeId)->name.str);
+		v->tname = strf(&v->tname_buf, "%s", find_node(v->t._enum.typeId)->name.str);
 		break;
 	case Type__struct:
 	case Type__interface:


### PR DESCRIPTION
This *should* fix #38. However, I haven't yet had time to write a test and see it fail/pass with my patch here, or test it on a more complex system.

This will also break code that uses `enum Whatever` for Cap'n Proto enums, since this typedefs the enums as `uint16_t`. The fix is to simply drop the `enum` in calling code.