### PR TITLE
Fix bug where enums were treated interchangeably with uint16_t.

### DIFF
--- a/compiler/capnpc-c.c
+++ b/compiler/capnpc-c.c
@@ -236,8 +236,10 @@ static void decode_value(struct value* v, Type_ptr type, Value_ptr value, const 
 		break;
 	case Value_int16:
 	case Value_uint16:
-	case Value__enum:
 		v->intval = v->v.int16;
+		break;
+	case Value__enum:
+		v->intval = v->v._enum;
 		break;
 	case Value_int32:
 	case Value_uint32:
@@ -750,8 +752,9 @@ static void do_union(struct strings *s, struct node *n, struct field *first_fiel
 	 * only need to emit one switch block as the layout will line up
 	 * in the C union */
 	union_cases(s, n, first_field, (1 << Type__bool));
+	union_cases(s, n, first_field, (1 << Type__enum));
 	union_cases(s, n, first_field, (1 << Type_int8) | (1 << Type_uint8));
-	union_cases(s, n, first_field, (1 << Type_int16) | (1 << Type_uint16) | (1 << Type__enum));
+	union_cases(s, n, first_field, (1 << Type_int16) | (1 << Type_uint16));
 	union_cases(s, n, first_field, (1 << Type_int32) | (1 << Type_uint32) | (1 << Type_float32));
 	union_cases(s, n, first_field, (1 << Type_int64) | (1 << Type_uint64) | (1 << Type_float64));
 	union_cases(s, n, first_field, (1 << Type_text));


### PR DESCRIPTION
ANSI C makes no guarantee about the size of an enum, only that it will be the
minimum required integer type that can hold all the given values. Treating
enums as interchangeable with uint16_t data caused undefined behavoiur on
platforms where enums were always at least 32 bits.

----

This should fix #38. I believe it is impossible to write a Google Test test case that demonstrates this because C++ treats enums differently to C; but I could be wrong about that. I will see if I can do it.

Notwithstanding that, [here is a schema and code](https://github.com/detly/capnp-test) that demonstrates the bug (on platforms where an enum is minimum 32 bits ie. most modern PCs). It requires Valgrind to fully demonstrate — at the very least, it expects to link with Valgrind's client libraries, and uses them if you run the resulting binary under Valgrind/Memcheck.

Build with Meson, and use it like so:

```plain
$ meson build
$ meson compile -C build
$ valgrind build/capnp-test
```

If you run it without Valgrind, you should at least see:

    capnp-test: ../main.c:119: main: Assertion `thing_dec.first == EnumOne_oneA' failed.

Under Valgrind you'll also see the undefined memory it's attempting to access:

    Before: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
    After : 00000000ffffffff0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

(The `ff`s are undefined areas of memory; that is showing where in the decoded struct is defined and undefined.)