### PR TITLE
Two extra annotations: donotinclude and typedefto

### DIFF
--- a/compiler/c.capnp
+++ b/compiler/c.capnp
@@ -43,3 +43,6 @@ annotation fieldgetset @0xf72bc690355d66de (file): Void;
 annotation donotinclude @0x8c99797357b357e9 (file): UInt64;
 # do not generate an include directive for an import statement for the file with
 # the given ID
+
+annotation typedefto @0xcefaf27713042144 (struct, enum): Text;
+# generate a typedef for the annotated struct or enum declaration

--- a/compiler/c.capnp
+++ b/compiler/c.capnp
@@ -39,3 +39,7 @@ annotation fieldgetset @0xf72bc690355d66de (file): Void;
 # generate getter & setter functions for accessing fields
 #
 # allows grabbing/putting values without de-/encoding the entire struct.
+
+annotation donotinclude @0x8c99797357b357e9 (file): UInt64;
+# do not generate an include directive for an import statement for the file with
+# the given ID

--- a/compiler/capnpc-c.c
+++ b/compiler/capnpc-c.c
@@ -1043,7 +1043,7 @@ static void define_struct(struct node *n) {
 	// adding the ability to get the structure size
 	str_addf(&HDR, "\nstatic const size_t %s_word_count = %d;\n", n->name.str, n->n._struct.dataWordCount);
 	str_addf(&HDR, "\nstatic const size_t %s_pointer_count = %d;\n", n->name.str, n->n._struct.pointerCount);
-	str_addf(&HDR, "\nstatic const size_t %s_struct_bytes_count = %d;\n", n->name.str, 8 * (n->n._struct.pointerCount + n->n._struct.dataWordCount));
+	str_addf(&HDR, "\nstatic const size_t %s_struct_bytes_count = %d;\n\n", n->name.str, 8 * (n->n._struct.pointerCount + n->n._struct.dataWordCount));
 
 	str_addf(&SRC, "%s_list new_%s_list(struct capn_segment *s, int len) {\n", n->name.str, n->name.str);
 	str_addf(&SRC, "\t%s_list p;\n", n->name.str);

--- a/compiler/capnpc-c.c
+++ b/compiler/capnpc-c.c
@@ -191,6 +191,24 @@ static void define_enum(struct node *n) {
 		str_addf(&HDR, "\n\t%s_%s = %d", n->name.str, e.name.str, i);
 	}
 	str_addf(&HDR, "\n};\n");
+
+	for (i = capn_len(n->n.annotations)-1; i >= 0; i--) {
+		struct Annotation a;
+		struct Value v;
+		get_Annotation(&a, n->n.annotations, i);
+		read_Value(&v, a.value);
+
+		switch (a.id) {
+		case 0xcefaf27713042144UL:
+			if (v.which != Value_text) {
+				fprintf(stderr, "schema breakage on $C::typedefto annotation\n");
+				exit(2);
+			}
+
+			str_addf(&HDR, "\ntypedef enum %s %s;\n", n->name.str, v.text.str);
+			break;
+		}
+	}
 }
 
 static void decode_value(struct value* v, Type_ptr type, Value_ptr value, const char *symbol) {
@@ -1007,6 +1025,7 @@ static void define_group(struct strings *s, struct node *n, const char *group_na
 
 static void define_struct(struct node *n) {
 	static struct strings s;
+	int i;
 
 	str_reset(&s.dtab);
 	str_reset(&s.ftab);
@@ -1033,6 +1052,24 @@ static void define_struct(struct node *n) {
 			n->name.str);
 	str_add(&HDR, s.decl.str, s.decl.len);
 	str_addf(&HDR, "};\n");
+
+	for (i = capn_len(n->n.annotations)-1; i >= 0; i--) {
+		struct Annotation a;
+		struct Value v;
+		get_Annotation(&a, n->n.annotations, i);
+		read_Value(&v, a.value);
+
+		switch (a.id) {
+		case 0xcefaf27713042144UL:
+			if (v.which != Value_text) {
+				fprintf(stderr, "schema breakage on $C::typedefto annotation\n");
+				exit(2);
+			}
+
+			str_addf(&HDR, "\ntypedef struct %s %s;\n", n->name.str, v.text.str);
+			break;
+		}
+	}
 
 	str_addf(&SRC, "\n%s_ptr new_%s(struct capn_segment *s) {\n", n->name.str, n->name.str);
 	str_addf(&SRC, "\t%s_ptr p;\n", n->name.str);


### PR DESCRIPTION
This adds two extra annotations:

## donotinclude

Currently the code generator assumes that every schema `import` statement requires a `#include` directive in the corresponding generated code. However this is not always the case eg. a schema that contains only annotation declarations doesn't generate any code. The best example of this is `c.capnp.h` itself (see #22) but also other language bindings eg. Rust's `rust.capnp` contains only annotations too.

Ideally the generator could detect this and suppress `#include` directives for any such schema file, however I couldn't figure out how to do this without multiple passes over input files and massive refactoring. The next best solution I could come up with was to have an annotation at the file level that declares that a particular ID should not result in a `#include` statement. For example, in the user's schema, they would have:

```capnp
using C = import "/capnp/c.capnp";

$C.donotinclude(0xc0183dd65ffef0f3);
```

Note that `0xc0183dd65ffef0f3` is the file ID for `c.capnp`. It does not matter whether the `donotinclude` annotation comes before or after the import statement. Multiple annotations are fine:

```capnp
using C = import "/capnp/c.capnp";
using Rust = import "rust.capnp";

$C.donotinclude(0xc0183dd65ffef0f3);
$C.donotinclude(0x83b3c14c3c8dd083);
```

## typedefto

This is purely cosmetic. This annotation lets you declare that a struct or enum must have a typedef generated for it with a given name. For example:

```capnp
enum FanSpeed $C.typedefto("fan_speed_t") {
    high @0;
    low @1;
}
```

...will result in the following typedef:

```c
typedef enum FanSpeed fan_speed_t;
```

I did this so that code can look a little more consistent with local style guides at the calling sites. Eventually it might be nice to implement a full camelCase/snake_case conversion, but that is a great deal more work.

It does not support doing this for the "which" enums created for unions.