### PR TITLE
Allow field name to be 'p'.

### DIFF
--- a/compiler/capnpc-c.c
+++ b/compiler/capnpc-c.c
@@ -657,6 +657,8 @@ static const char *field_name(struct field *f) {
 		"restrict", "_Alignas", "_Alignof", "_Atomic", "_Bool",
 		"_Complex", "_Generic", "_Imaginary", "_Noreturn", "_Static_assert",
 		"_Thread_local",
+		/* capn reserved for parameter names */
+		"p",
 	};
 
 	size_t i;


### PR DESCRIPTION
Without this change, when someone declares some field with name 'p' capnproto generates
code that does not compile due to duplicate parameters with same name:

In file included from proj.capnp.c:1:
./proj.capnp.h:166:41: error: redefinition of parameter 'p'
void Proj_set_p(Proj_ptr p, uint8_t p);
                                        ^
[....]
proj.capnp.c:189:10: error: redefinition of 'p' with a different type:
      'uint8_t' (aka 'unsigned char') vs 'Proj_ptr'
        uint8_t p;
                ^
proj.capnp.c:187:33: note: previous definition is here
uint8_t Proj_get_p(Proj_ptr p)
                                ^
