### PR TITLE
Change capn_write_mem return value from int to int64_t

### DIFF
--- a/lib/capn-malloc.c
+++ b/lib/capn-malloc.c
@@ -230,7 +230,7 @@ static int header_render(struct capn *c, struct capn_segment *seg, uint32_t *hea
 	return 0;
 }
 
-static int capn_write_mem_packed(struct capn *c, uint8_t *p, size_t sz)
+static int64_t capn_write_mem_packed(struct capn *c, uint8_t *p, size_t sz)
 {
 	struct capn_segment *seg;
 	struct capn_ptr root;
@@ -270,10 +270,10 @@ static int capn_write_mem_packed(struct capn *c, uint8_t *p, size_t sz)
 			return -1;
 	}
 
-	return sz - z.avail_out;
+	return (int64_t)(sz - z.avail_out);
 }
 
-int
+int64_t
 capn_write_mem(struct capn *c, uint8_t *p, size_t sz, int packed)
 {
 	struct capn_segment *seg;
@@ -310,7 +310,7 @@ capn_write_mem(struct capn *c, uint8_t *p, size_t sz, int packed)
 		p += seg->len;
 	}
 
-	return headersz+datasz;
+	return (int64_t)(headersz + datasz);
 }
 
 static int _write_fd(ssize_t (*write_fd)(int fd, const void *p, size_t count), int fd, void *p, size_t count)

--- a/lib/capnp_c.h
+++ b/lib/capnp_c.h
@@ -282,7 +282,7 @@ int capn_init_mem(struct capn *c, const uint8_t *p, size_t sz, int packed);
 /* TODO */
 /*int capn_write_fp(struct capn *c, FILE *f, int packed);*/
 int capn_write_fd(struct capn *c, ssize_t (*write_fd)(int fd, const void *p, size_t count), int fd, int packed);
-int capn_write_mem(struct capn *c, uint8_t *p, size_t sz, int packed);
+int64_t capn_write_mem(struct capn *c, uint8_t *p, size_t sz, int packed);
 
 void capn_free(struct capn *c);
 void capn_reset_copy(struct capn *c);


### PR DESCRIPTION
This PR is to change the return value type of `capn_write_mem()` from `int` to `int64_t`. It resolves the issue #40 .