### PR TITLE
Use int64_t for the return value of capn_size(). 

### DIFF
--- a/lib/capn-malloc.c
+++ b/lib/capn-malloc.c
@@ -408,7 +408,7 @@ int capn_write_fd(struct capn *c, ssize_t (*write_fd)(int fd, const void *p, siz
 	return datasz;
 }
 
-int capn_size(struct capn *c)
+int64_t capn_size(struct capn *c)
 {
 	size_t headersz, datasz = 0;
 	struct capn_ptr root;
@@ -431,5 +431,5 @@ int capn_size(struct capn *c)
 	if (0 != seg)
 		return -1;
 
-	return (int) headersz+datasz;
+	return (int64_t)(headersz + datasz);
 }

--- a/lib/capnp_c.h
+++ b/lib/capnp_c.h
@@ -282,7 +282,7 @@ int capn_init_mem(struct capn *c, const uint8_t *p, size_t sz, int packed);
  * input. A buffer of this size can then be passed to capn_write_mem() without
  * fear of truncation (again, only in the unpacked case).
  */
-int capn_size(struct capn *c);
+int64_t capn_size(struct capn *c);
 
 /* capn_write_(fp|mem) writes segments to the file/memory buffer in
  * serialized form and returns the number of bytes written.


### PR DESCRIPTION
This makes it consistent with a recent change to `capn_write_mem()` (#47).