### PR TITLE
add a capnp annotation for creating name spaces

### DIFF
--- a/compiler/c.capnp
+++ b/compiler/c.capnp
@@ -46,3 +46,6 @@ annotation donotinclude @0x8c99797357b357e9 (file): UInt64;
 
 annotation typedefto @0xcefaf27713042144 (struct, enum): Text;
 # generate a typedef for the annotated struct or enum declaration
+
+annotation namespace @0xf2c035025fec7c2b (file): Text;
+# prefix structs with a name space string


### PR DESCRIPTION
This patch adds an annotation for creating name spaces within capnproto files with the C-language code generator.

Use the annotation like this:
```
  using C = import "/c.capnp";
  $C.namespace("foo_");
```
The string passed into the namespace annotation is prepended to the name of all the struct's in the schema file.