### PR TITLE
Initial Meson build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ capnpc-c
 c-capnproto.pc
 
 *.tar.gz
+
+subprojects/googletest-*
+subprojects/packagecache

--- a/README.md
+++ b/README.md
@@ -23,13 +23,22 @@ capnpc compiler/test.capnp -oc
 ## Building on Linux
 
 ```sh
-git clone https://github.com/opensourcerouting/c-capnproto
+git clone --recurse-submodules https://github.com/opensourcerouting/c-capnproto
 cd c-capnproto
-git submodule update --init --recursive
 autoreconf -f -i -s
 ./configure
 make
 make check
+```
+
+## Building with Meson
+
+```sh
+git clone --recurse-submodules https://github.com/opensourcerouting/c-capnproto
+cd c-capnproto
+meson setup build
+meson compile -C build
+build/capn-test
 ```
 
 ## Usage

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,77 @@
+project('capnp-c', ['c','cpp'], meson_version: '>=1.0.0', default_options : ['c_std=c99', 'cpp_std=c++14'])
+
+cc = meson.get_compiler('c')
+
+common_c_args = []
+common_cpp_args = ['-std=c++14']
+libcapnp_c_args = []
+libcapnp_src = [
+  'lib' / 'capn-malloc.c',
+  'lib' / 'capn-stream.c',
+  'lib' / 'capn.c',
+]
+
+libcapnp = library('capnp', libcapnp_src,
+    c_args : common_c_args + libcapnp_c_args,
+    dependencies: [],
+    implicit_include_directories: false,
+    include_directories: include_directories(['compiler', 'lib'])
+)
+
+libcapnp_dep = declare_dependency(
+    link_with: libcapnp,
+    dependencies: [],
+    include_directories: include_directories(['compiler', 'lib'])
+)
+
+capnpc_src = [
+  'compiler' / 'capnpc-c.c',
+  'compiler' / 'schema.capnp.c',
+  'compiler' / 'str.c'
+]
+
+capnpc_c = executable('capnpc-c', capnpc_src,
+      include_directories: include_directories(['lib']),
+      dependencies: [libcapnp_dep],
+      c_args : common_c_args,
+)
+
+capn_test_src = [
+  'tests' / 'capn-test.cpp',
+  'tests' / 'capn-stream-test.cpp',
+  'tests' / 'example-test.cpp',
+  'tests' / 'addressbook.capnp.c',
+  'compiler' / 'test.capnp.c',
+  'compiler' / 'schema-test.cpp',
+  'compiler' / 'schema.capnp.c'
+]
+
+if get_option('enable_tests') and not meson.is_subproject()
+
+  thread_dep = dependency('threads')
+
+  gtest_proj = subproject('gtest')
+  gtest_dep = gtest_proj.get_variable('gtest_dep')
+  gmock_dep = gtest_proj.get_variable('gmock_dep')
+
+  test_dependencies = [libcapnp_dep, gtest_dep, gmock_dep, thread_dep]
+
+  if get_option('b_sanitize').contains('address')
+    test_dependencies += cc.find_library('asan')
+  endif
+  if get_option('b_sanitize').contains('undefined')
+    test_dependencies += cc.find_library('ubsan')
+  endif
+
+  exe = executable('capn-test', capn_test_src,
+      include_directories: include_directories(['lib', 'tests', 'compiler']),
+      dependencies: test_dependencies,
+      c_args : common_c_args,
+      cpp_args : common_cpp_args,
+      install: false,
+      install_rpath: '',
+      implicit_include_directories: false
+    )
+  test('capn-test', exe)
+
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('enable_tests', type: 'boolean', value: true, description: 'Build unit tests in test/ and compiler/')

--- a/subprojects/gtest.wrap
+++ b/subprojects/gtest.wrap
@@ -1,0 +1,15 @@
+[wrap-file]
+directory = googletest-1.13.0
+source_url = https://github.com/google/googletest/archive/refs/tags/v1.13.0.tar.gz
+source_filename = gtest-1.13.0.tar.gz
+source_hash = ad7fdba11ea011c1d925b3289cf4af2c66a352e18d4c7264392fead75e919363
+patch_filename = gtest_1.13.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/gtest_1.13.0-1/get_patch
+patch_hash = 6d82a02c3a45071cea989983bf6becde801cbbfd29196ba30dada0215393b082
+wrapdb_version = 1.13.0-1
+
+[provide]
+gtest = gtest_dep
+gtest_main = gtest_main_dep
+gmock = gmock_dep
+gmock_main = gmock_main_dep


### PR DESCRIPTION
How to use:
```bash
$ meson setup build
$ ninja -C build
$ build/capn-test
```

Fixes https://github.com/opensourcerouting/c-capnproto/issues/56